### PR TITLE
Update postInitScript.js

### DIFF
--- a/postInitScript.js
+++ b/postInitScript.js
@@ -4,4 +4,4 @@ const { execSync } = require('child_process');
 
 // initialise git repo for the project for Husky to work
 const projectPath = process.cwd();
-execSync(`git init ${projectPath}`);
+execSync(`git init "${projectPath}"`);


### PR DESCRIPTION
Without double quotes, the script fails when the path contains spaces